### PR TITLE
:fix: explicitly get refresh_token from credentials 

### DIFF
--- a/config_vars.py
+++ b/config_vars.py
@@ -1,5 +1,6 @@
 import os
 import platform
+import json
 from subprocess import DEVNULL, STDOUT, check_call
 
 def set_heroku_vars(token_name='EARTHENGINE_TOKEN'):
@@ -16,13 +17,11 @@ def set_heroku_vars(token_name='EARTHENGINE_TOKEN'):
         if not os.path.exists(ee_token_file):
             print('The credentials file does not exist.')
         else:
+
             with open(ee_token_file) as f:
                 content = f.read()
-                token = content.split(':')[1].strip()[1:-2]
-                # if platform.system() == 'Linux':
-                #     token = content.split(':')[1][1:-3]
-                # else:
-                #     token = content.split(':')[1][2:-2]
+                content_json = json.loads(content)
+                token = content_json["refresh_token"]
                 secret = '{}={}'.format(token_name, token)
                 if platform.system() == 'Windows':
                     check_call(['heroku', 'config:set', secret], stdout=DEVNULL, stderr=STDOUT, shell=True)


### PR DESCRIPTION
Not sure if this complicates things or makes them easier, but after also having authentification issues it became clear that config_vars.py retrieved the client_id value rather than the refresh_token -- the client_id worked for local deployment (but not clear if the browser cache actually made that possible) but not remote deployment. When the refresh_token is used, however, it authenticates properly for both local and remote apps.